### PR TITLE
Add baseline Discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # Duescord
-A discord bot that helps organizations track dues
+
+A simple Discord bot that tracks member dues using a local SQLite database.
+
+## Requirements
+
+- Python 3.8+
+- `discord.py` library
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the Bot
+
+Set your Discord bot token as an environment variable:
+
+```bash
+export DISCORD_TOKEN="your bot token here"
+```
+
+Then start the bot:
+
+```bash
+python bot.py
+```
+
+Use the `!register` command in your server to add a member:
+
+```
+!register <name> <paid> [comment]
+```
+
+- `name`: The member's name.
+- `paid`: `True` if dues are paid, `False` otherwise.
+- `comment`: Optional comment about the member.
+
+Members are stored in the `duescord.db` SQLite database.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,49 @@
+import os
+import asyncio
+import sqlite3
+from discord.ext import commands
+
+# Database initialization
+DB_PATH = 'duescord.db'
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        'CREATE TABLE IF NOT EXISTS members ('
+        'id INTEGER PRIMARY KEY AUTOINCREMENT,'
+        'name TEXT NOT NULL,'
+        'paid INTEGER NOT NULL,'
+        'comment TEXT'
+        ')'
+    )
+    conn.commit()
+    conn.close()
+
+# Bot setup
+bot = commands.Bot(command_prefix='!')
+
+@bot.event
+async def on_ready():
+    print(f'Logged in as {bot.user}')
+
+@bot.command(name='register')
+async def register(ctx, name: str, paid: bool, *, comment: str = None):
+    """Register a user with dues status and optional comment."""
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        'INSERT INTO members (name, paid, comment) VALUES (?, ?, ?)',
+        (name, int(paid), comment)
+    )
+    conn.commit()
+    conn.close()
+    await ctx.send(f"Registered {name} with paid={paid}.")
+
+if __name__ == '__main__':
+    init_db()
+    TOKEN = os.getenv('DISCORD_TOKEN')
+    if not TOKEN:
+        print('DISCORD_TOKEN environment variable not set.')
+    else:
+        bot.run(TOKEN)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+discord.py


### PR DESCRIPTION
## Summary
- create `bot.py` for a simple Discord bot using SQLite
- document usage in `README.md`
- add `requirements.txt`

## Testing
- `python3 -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6846606af6cc832b909d85186cc2f072