### PR TITLE
Add start script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.duescord.db
+*.db
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+duescord.db
+__pycache__/
+*.pyc
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+# Default path where the database will be stored. Can be overridden at runtime.
+ENV DATABASE_PATH=/data/duescord.db
+VOLUME ["/data"]
+CMD ["python", "bot.py"]

--- a/README.md
+++ b/README.md
@@ -38,3 +38,40 @@ Use the `!register` command in your server to add a member:
 - `comment`: Optional comment about the member.
 
 Members are stored in the `duescord.db` SQLite database.
+
+## Running with Docker
+
+You can also run the bot in a Docker container. The provided image
+stores the database in `/data/duescord.db` by default. Mount a host
+directory to persist the database between runs:
+
+```bash
+# Build the image
+docker build -t duescord .
+
+# Run the bot (replace YOUR_TOKEN with your bot token)
+docker run -e DISCORD_TOKEN=YOUR_TOKEN \
+    -v $(pwd)/data:/data duescord
+
+```
+
+Alternatively, use `docker-compose` which automatically mounts the
+`data/` directory:
+
+```bash
+DISCORD_TOKEN=YOUR_TOKEN docker compose up
+```
+
+The database path can be customised with the `DATABASE_PATH`
+environment variable.
+
+### Quick start script
+
+For convenience, a `start.sh` script is provided that builds the Docker
+image (if needed) and launches the bot with `docker compose`.
+
+```bash
+DISCORD_TOKEN=YOUR_TOKEN ./start.sh
+```
+
+The database will be stored in the `data/` directory by default.

--- a/bot.py
+++ b/bot.py
@@ -4,9 +4,15 @@ import sqlite3
 from discord.ext import commands
 
 # Database initialization
-DB_PATH = 'duescord.db'
+# Allow configuring the database location with an environment variable so
+# Docker volumes or custom paths can be used for persistence.
+DB_PATH = os.getenv('DATABASE_PATH', 'duescord.db')
 
 def init_db():
+    # Ensure the directory for the database exists
+    db_dir = os.path.dirname(DB_PATH)
+    if db_dir:
+        os.makedirs(db_dir, exist_ok=True)
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  bot:
+    build: .
+    environment:
+      - DISCORD_TOKEN=${DISCORD_TOKEN}
+      - DATABASE_PATH=/data/duescord.db
+    volumes:
+      - ./data:/data

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Simple script to start the Duescord bot using docker-compose.
+# Requires the DISCORD_TOKEN environment variable to be set.
+
+set -e
+
+if [ -z "$DISCORD_TOKEN" ]; then
+  echo "DISCORD_TOKEN environment variable not set" >&2
+  exit 1
+fi
+
+# Build the image if necessary and start the container
+exec docker compose up --build


### PR DESCRIPTION
## Summary
- provide start.sh helper for running in Docker
- document start.sh usage in README

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_684afcaf3e24832bb69f207c171bf1a5