### PR TITLE
Add members summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Use the `!register` command in your server to add a member:
 - `paid`: `True` if dues are paid, `False` otherwise.
 - `comment`: Optional comment about the member.
 
+Use the `!members` command to view a table of all registered members along
+with their paid status and any comments.
+
 Members are stored in the `duescord.db` SQLite database.
 
 ## Running with Docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 discord.py
+tabulate


### PR DESCRIPTION
## Summary
- show a table of members in the database via new `!members` command
- add `tabulate` dependency
- mention new command in README

## Testing
- `pip install -r requirements.txt`
- `DISCORD_TOKEN=dummy python bot.py` *(fails to connect to Discord: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684b02652060832b848379071fbf5c5f