### PR TITLE
Add table clearing confirmation and update register

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,16 @@ python bot.py
 Use the `!register` command in your server to add a member:
 
 ```
-!register <name> <paid> [comment]
+!register <first> [last] <paid> [comment]
 ```
 
-- `name`: The member's name.
+- `first`: The member's first name.
+- `last`: Optional last name.
 - `paid`: `True` if dues are paid, `False` otherwise.
 - `comment`: Optional comment about the member.
+
+You can remove **all** members with the `!clear_table` command, but you
+must confirm the action a second time to prevent accidents.
 
 Use the `!members` command to view a table of all registered members along
 with their paid status and any comments.

--- a/bot.py
+++ b/bot.py
@@ -33,23 +33,70 @@ intents = discord.Intents.default()
 intents.message_content = True
 bot = commands.Bot(command_prefix='!', intents=intents)
 
+# Track users who have requested to clear the table but have not yet
+# confirmed. Mapping of user ID to a task that removes the pending state
+# after a timeout.
+_pending_clears = {}
+
+
+def _parse_bool(value: str):
+    """Return True or False if value looks like a boolean, otherwise None."""
+    v = value.lower()
+    if v in {"true", "1", "yes", "y"}:
+        return True
+    if v in {"false", "0", "no", "n"}:
+        return False
+    return None
+
 
 @bot.event
 async def on_ready():
     print(f'Logged in as {bot.user}')
 
 @bot.command(name='register')
-async def register(ctx, name: str, paid: bool, *, comment: str = None):
-    """Register a user with dues status and optional comment."""
+async def register(ctx, *, args: str):
+    """Register a user with dues status and optional comment.
+
+    Usage: !register <first> [last] <paid> [comment]
+    """
+    tokens = args.split()
+    if len(tokens) < 2:
+        await ctx.send("Usage: !register <first> [last] <paid> [comment]")
+        return
+
+    # Determine if the second or third token is the paid flag
+    paid_token = None
+    first = tokens[0]
+    last = None
+    comment_tokens = []
+    if len(tokens) >= 3 and _parse_bool(tokens[2]) is not None:
+        last = tokens[1]
+        paid_token = tokens[2]
+        comment_tokens = tokens[3:]
+    elif _parse_bool(tokens[1]) is not None:
+        paid_token = tokens[1]
+        comment_tokens = tokens[2:]
+    else:
+        await ctx.send("Usage: !register <first> [last] <paid> [comment]")
+        return
+
+    paid_val = _parse_bool(paid_token)
+    if paid_val is None:
+        await ctx.send("Paid value must be true or false")
+        return
+
+    name = first + (" " + last if last else "")
+    comment = " ".join(comment_tokens) if comment_tokens else None
+
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute(
         'INSERT INTO members (name, paid, comment) VALUES (?, ?, ?)',
-        (name, int(paid), comment)
+        (name, int(paid_val), comment)
     )
     conn.commit()
     conn.close()
-    await ctx.send(f"Registered {name} with paid={paid}.")
+    await ctx.send(f"Registered {name} with paid={paid_val}.")
 
 @bot.command(name='members')
 async def members(ctx):
@@ -66,6 +113,37 @@ async def members(ctx):
 
     table = tabulate(rows, headers=['Name', 'Paid', 'Comment'], tablefmt='pretty')
     await ctx.send(f"```\n{table}\n```")
+
+
+@bot.command(name='clear_table')
+async def clear_table(ctx, confirm: str = None):
+    """Delete all members after a second confirmation."""
+    user_id = ctx.author.id
+
+    if confirm != 'confirm':
+        # First step: ask for confirmation
+        if user_id in _pending_clears:
+            _pending_clears[user_id].cancel()
+        async def timeout():
+            await asyncio.sleep(30)
+            _pending_clears.pop(user_id, None)
+        task = asyncio.create_task(timeout())
+        _pending_clears[user_id] = task
+        await ctx.send('This will remove **all** members. Run `!clear_table confirm` within 30 seconds to proceed.')
+        return
+
+    task = _pending_clears.pop(user_id, None)
+    if task is None:
+        await ctx.send('Please run `!clear_table` first to confirm.')
+        return
+    task.cancel()
+
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('DELETE FROM members')
+    conn.commit()
+    conn.close()
+    await ctx.send('All members have been removed.')
 
 if __name__ == '__main__':
     init_db()


### PR DESCRIPTION
## Summary
- allow register to accept an optional last name
- add `!clear_table` command requiring double confirmation
- document new commands in README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_684edcf05060832b9845e418f8c751a7