### PR TITLE
Add unpay_all command and custom help

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Additional commands:
 - `!find <query>` – search names or comments for a keyword.
 - `!unpaid` – list only members who have not paid.
 - `!stats` – show counts of total, paid and unpaid members.
+- `!unpay_all` – mark all members as unpaid.
+- `!help` – display a summary of commands.
 
 Members are stored in the `duescord.db` SQLite database.
 

--- a/bot.py
+++ b/bot.py
@@ -31,7 +31,7 @@ def init_db():
 # Bot setup
 intents = discord.Intents.default()
 intents.message_content = True
-bot = commands.Bot(command_prefix='!', intents=intents)
+bot = commands.Bot(command_prefix='!', intents=intents, help_command=None)
 
 # Track users who have requested to clear the table but have not yet
 # confirmed. Mapping of user ID to a task that removes the pending state
@@ -240,6 +240,36 @@ async def stats(ctx):
     unpaid = total - paid
     conn.close()
     await ctx.send(f'Total: {total}\nPaid: {paid}\nUnpaid: {unpaid}')
+
+
+@bot.command(name='unpay_all')
+async def unpay_all(ctx):
+    """Mark all members as unpaid."""
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('UPDATE members SET paid = 0')
+    conn.commit()
+    updated = c.rowcount
+    conn.close()
+    await ctx.send(f'Updated {updated} members to unpaid.')
+
+
+@bot.command(name='help')
+async def help_command(ctx):
+    """Show all commands and their usage."""
+    help_text = (
+        "!register <first> [last] <paid> [comment] - Register a member\n"
+        "!members - List all registered members\n"
+        "!clear_table [confirm] - Remove all members\n"
+        "!delete <id> - Remove a member\n"
+        "!update <id> <paid> [comment] - Update a member\n"
+        "!find <query> - Search for members\n"
+        "!unpaid - List unpaid members\n"
+        "!stats - Show member statistics\n"
+        "!unpay_all - Mark all members as unpaid\n"
+        "!help - Show this message"
+    )
+    await ctx.send(help_text)
 
 if __name__ == '__main__':
     init_db()


### PR DESCRIPTION
## Summary
- allow disabling default help command
- add `unpay_all` command that marks all members as unpaid
- implement `!help` command listing usage for all commands
- document new commands in the README

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6850ba70ea2c832bba96b76c3be0866a