### PR TITLE
Add Admin SQL Browser tab to web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,20 @@ DISCORD_TOKEN=YOUR_TOKEN ./start.sh
 ```
 
 The database will be stored in the `data/` directory by default.
+
+## Web interface
+
+Duescord now includes a lightweight web dashboard (enabled by default)
+available at `http://localhost:8080`.
+
+Environment variables:
+
+- `WEB_ENABLED` (default: `true`) – enable/disable the web server.
+- `WEB_HOST` (default: `0.0.0.0`) – host interface to bind.
+- `WEB_PORT` (default: `8080`) – port for the web server.
+- `WEB_SECRET_KEY` – Flask session secret (recommended in production).
+- `WEB_ADMIN_TOKEN` – required to enable the **Admin SQL Browser** tab.
+
+The dashboard includes tabs for Members, Tasks, and an Admin SQL Browser.
+When `WEB_ADMIN_TOKEN` is set, admins can log in through `/admin/login` and
+dynamically browse all SQL tables and rows from the database.

--- a/bot.py
+++ b/bot.py
@@ -1,10 +1,13 @@
 import os
 import asyncio
 import sqlite3
+import threading
+from functools import wraps
 from datetime import datetime, time
 from zoneinfo import ZoneInfo
 
 import discord
+from flask import Flask, jsonify, redirect, render_template_string, request, session, url_for
 from discord.ext import commands, tasks
 from tabulate import tabulate
 
@@ -56,6 +59,265 @@ bot = commands.Bot(command_prefix='!', intents=intents, help_command=None)
 CENTRAL_TZ = ZoneInfo('America/Chicago')
 
 MODERATOR_ROLE_NAME = os.getenv('MODERATOR_ROLE_NAME', 'Moderator')
+WEB_ENABLED = os.getenv('WEB_ENABLED', 'true').lower() in {'1', 'true', 'yes', 'on'}
+WEB_HOST = os.getenv('WEB_HOST', '0.0.0.0')
+WEB_PORT = int(os.getenv('WEB_PORT', '8080'))
+WEB_ADMIN_TOKEN = os.getenv('WEB_ADMIN_TOKEN')
+WEB_SECRET_KEY = os.getenv('WEB_SECRET_KEY', 'duescord-web-secret')
+
+web_app = Flask(__name__)
+web_app.secret_key = WEB_SECRET_KEY
+
+
+def _fetch_rows(query, params=()):
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    c.execute(query, params)
+    rows = c.fetchall()
+    conn.close()
+    return [dict(row) for row in rows]
+
+
+def _is_admin_logged_in():
+    return bool(WEB_ADMIN_TOKEN and session.get('is_admin'))
+
+
+def _admin_required(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not _is_admin_logged_in():
+            return jsonify({'error': 'Admin authentication required.'}), 403
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@web_app.route('/', methods=['GET'])
+def web_index():
+    members = _fetch_rows('SELECT id, name, paid, COALESCE(comment, "") AS comment FROM members ORDER BY id')
+    tasks = _fetch_rows(
+        'SELECT id, description, assignee_id, created_by, created_at, completed, completed_at '
+        'FROM tasks ORDER BY created_at DESC, id DESC'
+    )
+    return render_template_string(
+        """
+        <!doctype html>
+        <html>
+        <head>
+            <meta charset="utf-8">
+            <title>Duescord Dashboard</title>
+            <style>
+                body { font-family: Arial, sans-serif; margin: 2rem; }
+                .tabs { display: flex; gap: .5rem; margin-bottom: 1rem; }
+                .tab-btn { padding: .5rem .75rem; border: 1px solid #aaa; cursor: pointer; background: #f4f4f4; }
+                .tab-btn.active { background: #dce9ff; border-color: #4b74c6; }
+                .tab-panel { display: none; }
+                .tab-panel.active { display: block; }
+                table { border-collapse: collapse; width: 100%; margin-top: .5rem; }
+                th, td { border: 1px solid #ddd; padding: .4rem; text-align: left; }
+                th { background: #fafafa; }
+                .meta { margin-bottom: 1rem; color: #444; }
+                .actions { margin-bottom: .75rem; display: flex; gap: .5rem; align-items: center; }
+                .notice { padding: .6rem; background: #fff7df; border: 1px solid #efcf73; border-radius: .25rem; }
+            </style>
+        </head>
+        <body>
+            <h1>Duescord Web Interface</h1>
+            <div class="meta">
+                Admin mode: <strong>{{ "Enabled" if admin_token_set else "Disabled (set WEB_ADMIN_TOKEN)" }}</strong>
+                {% if admin_logged_in %}
+                    | Logged in as admin (<a href="{{ url_for('admin_logout') }}">logout</a>)
+                {% elif admin_token_set %}
+                    | <a href="{{ url_for('admin_login') }}">admin login</a>
+                {% endif %}
+            </div>
+            <div class="tabs">
+                <button class="tab-btn active" data-tab="members">Members</button>
+                <button class="tab-btn" data-tab="tasks">Tasks</button>
+                <button class="tab-btn" data-tab="admin">Admin SQL Browser</button>
+            </div>
+
+            <section id="members" class="tab-panel active">
+                <h2>Members</h2>
+                <table>
+                    <thead><tr><th>ID</th><th>Name</th><th>Paid</th><th>Comment</th></tr></thead>
+                    <tbody>
+                    {% for row in members %}
+                        <tr><td>{{ row.id }}</td><td>{{ row.name }}</td><td>{{ row.paid }}</td><td>{{ row.comment }}</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </section>
+
+            <section id="tasks" class="tab-panel">
+                <h2>Tasks</h2>
+                <table>
+                    <thead><tr><th>ID</th><th>Description</th><th>Assignee</th><th>Created By</th><th>Created At</th><th>Completed</th><th>Completed At</th></tr></thead>
+                    <tbody>
+                    {% for row in tasks %}
+                        <tr>
+                            <td>{{ row.id }}</td><td>{{ row.description }}</td><td>{{ row.assignee_id }}</td>
+                            <td>{{ row.created_by }}</td><td>{{ row.created_at }}</td><td>{{ row.completed }}</td><td>{{ row.completed_at or "" }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </section>
+
+            <section id="admin" class="tab-panel">
+                <h2>Admin SQL Browser</h2>
+                {% if not admin_token_set %}
+                    <div class="notice">Admin token not configured. Set <code>WEB_ADMIN_TOKEN</code> to enable this tab.</div>
+                {% elif not admin_logged_in %}
+                    <div class="notice">Please <a href="{{ url_for('admin_login') }}">login as admin</a> to browse SQL tables.</div>
+                {% else %}
+                    <div class="actions">
+                        <label for="table-select">Table:</label>
+                        <select id="table-select"></select>
+                        <button id="refresh-table">Load</button>
+                    </div>
+                    <div id="admin-table"></div>
+                {% endif %}
+            </section>
+
+            <script>
+                document.querySelectorAll('.tab-btn').forEach(btn => {
+                    btn.addEventListener('click', () => {
+                        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+                        document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+                        btn.classList.add('active');
+                        document.getElementById(btn.dataset.tab).classList.add('active');
+                    });
+                });
+
+                const tableSelect = document.getElementById('table-select');
+                const refreshBtn = document.getElementById('refresh-table');
+                const tableContainer = document.getElementById('admin-table');
+
+                async function loadTableList() {
+                    if (!tableSelect) return;
+                    const response = await fetch('/api/admin/tables');
+                    if (!response.ok) return;
+                    const data = await response.json();
+                    tableSelect.innerHTML = '';
+                    data.tables.forEach(table => {
+                        const option = document.createElement('option');
+                        option.value = table;
+                        option.textContent = table;
+                        tableSelect.appendChild(option);
+                    });
+                    if (data.tables.length > 0) {
+                        await loadTableData(data.tables[0]);
+                    }
+                }
+
+                async function loadTableData(tableName) {
+                    const response = await fetch(`/api/admin/table/${encodeURIComponent(tableName)}`);
+                    if (!response.ok) {
+                        tableContainer.innerHTML = '<div class="notice">Unable to load table data.</div>';
+                        return;
+                    }
+                    const data = await response.json();
+                    let html = '<table><thead><tr>';
+                    data.columns.forEach(col => { html += `<th>${col}</th>`; });
+                    html += '</tr></thead><tbody>';
+                    data.rows.forEach(row => {
+                        html += '<tr>';
+                        data.columns.forEach(col => {
+                            const value = row[col] ?? '';
+                            html += `<td>${value}</td>`;
+                        });
+                        html += '</tr>';
+                    });
+                    html += '</tbody></table>';
+                    tableContainer.innerHTML = html;
+                }
+
+                if (refreshBtn) {
+                    refreshBtn.addEventListener('click', async () => {
+                        if (tableSelect.value) await loadTableData(tableSelect.value);
+                    });
+                    tableSelect.addEventListener('change', async () => {
+                        if (tableSelect.value) await loadTableData(tableSelect.value);
+                    });
+                    loadTableList();
+                }
+            </script>
+        </body>
+        </html>
+        """,
+        members=members,
+        tasks=tasks,
+        admin_token_set=bool(WEB_ADMIN_TOKEN),
+        admin_logged_in=_is_admin_logged_in(),
+    )
+
+
+@web_app.route('/admin/login', methods=['GET', 'POST'])
+def admin_login():
+    if not WEB_ADMIN_TOKEN:
+        return redirect(url_for('web_index'))
+    error = None
+    if request.method == 'POST':
+        token = (request.form.get('token') or '').strip()
+        if token == WEB_ADMIN_TOKEN:
+            session['is_admin'] = True
+            return redirect(url_for('web_index'))
+        error = 'Invalid admin token.'
+    return render_template_string(
+        """
+        <h1>Duescord Admin Login</h1>
+        {% if error %}<p style="color: red;">{{ error }}</p>{% endif %}
+        <form method="post">
+            <label>Admin token: <input name="token" type="password" autofocus required></label>
+            <button type="submit">Login</button>
+        </form>
+        <p><a href="{{ url_for('web_index') }}">Back to dashboard</a></p>
+        """,
+        error=error,
+    )
+
+
+@web_app.route('/admin/logout', methods=['GET'])
+def admin_logout():
+    session.pop('is_admin', None)
+    return redirect(url_for('web_index'))
+
+
+@web_app.route('/api/admin/tables', methods=['GET'])
+@_admin_required
+def api_admin_tables():
+    rows = _fetch_rows(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    )
+    return jsonify({'tables': [row['name'] for row in rows]})
+
+
+@web_app.route('/api/admin/table/<table_name>', methods=['GET'])
+@_admin_required
+def api_admin_table_data(table_name):
+    available_tables = {
+        row['name']
+        for row in _fetch_rows("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
+    }
+    if table_name not in available_tables:
+        return jsonify({'error': 'Unknown table.'}), 404
+    column_rows = _fetch_rows(f'PRAGMA table_info("{table_name}")')
+    columns = [row['name'] for row in column_rows]
+    rows = _fetch_rows(f'SELECT * FROM "{table_name}" LIMIT 200')
+    return jsonify({'table': table_name, 'columns': columns, 'rows': rows})
+
+
+def _start_web_interface():
+    if not WEB_ENABLED:
+        print('Web interface disabled (set WEB_ENABLED=true to enable).')
+        return
+    thread = threading.Thread(
+        target=lambda: web_app.run(host=WEB_HOST, port=WEB_PORT, debug=False, use_reloader=False),
+        daemon=True,
+    )
+    thread.start()
+    print(f'Web interface running on http://{WEB_HOST}:{WEB_PORT}')
 
 
 def _has_named_role(member, role_name):
@@ -541,6 +803,7 @@ async def help_command(ctx):
 
 if __name__ == '__main__':
     init_db()
+    _start_web_interface()
     TOKEN = os.getenv('DISCORD_TOKEN')
     if not TOKEN:
         print('DISCORD_TOKEN environment variable not set.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py
 tabulate
+Flask


### PR DESCRIPTION
### Motivation
- Provide a lightweight web dashboard so admins can inspect application state and browse any SQLite table without using the DB file directly.
- Make members/tasks data visible in a simple UI and add an authenticated SQL browser for on-demand debugging and administration.

### Description
- Add a Flask-backed web app inside `bot.py` that renders a tabbed dashboard with `Members`, `Tasks`, and an `Admin SQL Browser` tab and client-side JS to load table lists and rows.
- Implement admin authentication using the `WEB_ADMIN_TOKEN` session flow with routes `/admin/login` and `/admin/logout` and protect JSON endpoints with an `_admin_required` wrapper for `/api/admin/tables` and `/api/admin/table/<table_name>`.
- Add small DB helper `_fetch_rows`, use `PRAGMA table_info()` to determine columns, and start the web server in a daemon thread via `_start_web_interface()` controlled by `WEB_ENABLED`, `WEB_HOST`, and `WEB_PORT` environment variables.
- Update `requirements.txt` to include `Flask` and document the web interface and new environment variables in `README.md`.

### Testing
- Installed runtime deps with `pip install -r requirements.txt` and the install completed successfully.
- Verified Python syntax via `python -m py_compile bot.py` which succeeded.
- Performed a Flask test-client smoke test that confirmed the index page returns `200`, the admin API returns `403` when unauthenticated, and returns `200` after posting the correct `WEB_ADMIN_TOKEN` to `/admin/login`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabf174f38832baf2a0f1f038db332)